### PR TITLE
fix: stabilize client runtime flows

### DIFF
--- a/src/components/Infomap/Infomap.js
+++ b/src/components/Infomap/Infomap.js
@@ -40,32 +40,34 @@ export default observer(function InfomapOnline({ toast }) {
   const [error, setError] = useState("");
   const [progress, setProgress] = useState(0);
 
-  const infomap = new Infomap()
-    .on("data", (data) => setInfomapOutput((output) => [...output, data]))
-    .on("progress", (progress) => setProgress(progress))
-    .on("error", (error) => {
-      const infomapError = error.replace(/^Error:\s+/i, "");
-      setError(infomapError);
-      setInfomapOutput((output) => [...output, error]);
-      setIsRunning(false);
-      setIsCompleted(false);
-      toast({ title: "Error", description: infomapError, status: "error" });
-    })
-    .on("finished", async (content) => {
-      store.output.setContent(content);
-      await localforage.setItem("network", {
-        timestamp: Date.now(),
-        name: store.network.name,
-        input: store.network.value,
-        ...content,
-      });
-      setIsRunning(false);
-      setIsCompleted(true);
-      setProgress(0);
-      if (window.navigator?.vibrate) {
-        window.navigator.vibrate([200, 100, 200, 100, 200]);
-      }
-    });
+  const [infomap] = useState(() =>
+    new Infomap()
+      .on("data", (data) => setInfomapOutput((output) => [...output, data]))
+      .on("progress", (progress) => setProgress(progress))
+      .on("error", (error) => {
+        const infomapError = error.replace(/^Error:\s+/i, "");
+        setError(infomapError);
+        setInfomapOutput((output) => [...output, error]);
+        setIsRunning(false);
+        setIsCompleted(false);
+        toast({ title: "Error", description: infomapError, status: "error" });
+      })
+      .on("finished", async (content) => {
+        store.output.setContent(content);
+        await localforage.setItem("network", {
+          timestamp: Date.now(),
+          name: store.network.name,
+          input: store.network.value,
+          ...content,
+        });
+        setIsRunning(false);
+        setIsCompleted(true);
+        setProgress(0);
+        if (window.navigator?.vibrate) {
+          window.navigator.vibrate([200, 100, 200, 100, 200]);
+        }
+      })
+  );
 
   useEffect(() => {
     const args = new URLSearchParams(window.location.search).get("args");

--- a/src/components/Network/Renderer.jsx
+++ b/src/components/Network/Renderer.jsx
@@ -3,7 +3,7 @@ import * as c3 from "@mapequation/c3";
 import Infomap from "@mapequation/infomap";
 import * as d3 from "d3";
 import { observer } from "mobx-react";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import useStore from "../../store";
 
 const MAX_COLORS = 100;
@@ -25,14 +25,19 @@ export default observer(function Renderer({ scheme: schemeName }) {
 
   const scheme = c3.colors(MAX_COLORS, { scheme: schemeName, lightness: 0.8 });
 
-  const nodeRadius = d3
-    .scaleSqrt([0, maxNodeFlow])
-    .range([minRadius, maxRadius]);
+  const nodeRadius = useMemo(
+    () => d3.scaleSqrt([0, maxNodeFlow]).range([minRadius, maxRadius]),
+    [maxNodeFlow]
+  );
 
-  const linkWidth = d3
-    .scaleLinear()
-    .domain([0, maxLinkFlow])
-    .range([minLinkWidth, maxLinkWidth]);
+  const linkWidth = useMemo(
+    () =>
+      d3
+        .scaleLinear()
+        .domain([0, maxLinkFlow])
+        .range([minLinkWidth, maxLinkWidth]),
+    [maxLinkFlow]
+  );
 
   const fill = (node) => {
     const moduleId = store.output.modules.get(node.id);
@@ -45,7 +50,7 @@ export default observer(function Renderer({ scheme: schemeName }) {
   };
 
   useEffect(() => {
-    console.log("Network run Infomap");
+    let isCancelled = false;
 
     im.runAsync({
       network: store.network.value,
@@ -53,17 +58,27 @@ export default observer(function Renderer({ scheme: schemeName }) {
     })
       .then((result) => parseNetwork(result.flow_as_physical || result.flow))
       .then(({ maxNodeFlow, maxLinkFlow, ...network }) => {
+        if (isCancelled) {
+          return;
+        }
         setNetwork(network);
         setMaxNodeFlow(maxNodeFlow);
         setMaxLinkFlow(maxLinkFlow);
         setDirected(/(-d\s)|(--directed\s)/.test(store.params.noInfomapArgs));
       })
-      .catch((error) => console.warn(error));
+      .catch((error) => {
+        if (!isCancelled) {
+          console.warn(error);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
   }, [store.network.value, store.params.noInfomapArgs]);
 
   useEffect(() => {
     if (!network) return;
-    console.log("Network update simulation");
 
     const simulation = d3
       .forceSimulation(network.nodes)
@@ -138,6 +153,11 @@ export default observer(function Renderer({ scheme: schemeName }) {
       circle.attr("cx", (d) => d.x).attr("cy", (d) => d.y);
       text.attr("x", (d) => d.x).attr("y", (d) => d.y);
     });
+
+    return () => {
+      simulation.stop();
+      node.on(".drag", null);
+    };
   }, [network, directed, nodeRadius, linkWidth]);
 
   const linkColor = "#ccc";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import type { NextPage } from "next";
 import Head from "next/head";
+import Script from "next/script";
 import dynamic from "next/dynamic";
 import { HamburgerIcon } from "@chakra-ui/icons";
 import {
@@ -39,6 +40,23 @@ const Home: NextPage = () => {
           Infomap - Network community detection using the Map Equation framework
         </title>
       </Head>
+      <Script
+        src="https://www.googletagmanager.com/gtag/js?id=UA-27168379-1"
+        onLoad={() => {
+          // @ts-ignore
+          window.dataLayer = window.dataLayer || [];
+
+          function gtag() {
+            // @ts-ignore
+            dataLayer.push(arguments);
+          }
+
+          // @ts-ignore
+          gtag("js", new Date());
+          // @ts-ignore
+          gtag("config", "UA-27168379-1");
+        }}
+      />
 
       <IconButton
         aria-label="contents"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import type { NextPage } from "next";
 import Head from "next/head";
-import Script from "next/script";
 import dynamic from "next/dynamic";
 import { HamburgerIcon } from "@chakra-ui/icons";
 import {
@@ -40,23 +39,6 @@ const Home: NextPage = () => {
           Infomap - Network community detection using the Map Equation framework
         </title>
       </Head>
-      <Script
-        src="https://www.googletagmanager.com/gtag/js?id=UA-27168379-1"
-        onLoad={() => {
-          // @ts-ignore
-          window.dataLayer = window.dataLayer || [];
-
-          function gtag() {
-            // @ts-ignore
-            dataLayer.push(arguments);
-          }
-
-          // @ts-ignore
-          gtag("js", new Date());
-          // @ts-ignore
-          gtag("config", "UA-27168379-1");
-        }}
-      />
 
       <IconButton
         aria-label="contents"

--- a/src/store/OutputStore/OutputStore.js
+++ b/src/store/OutputStore/OutputStore.js
@@ -289,7 +289,7 @@ export default class OutputStore {
         : "text/plain;charset=utf-8";
     const blob = new Blob([content], { type: mimeType });
     saveAs(blob, file.filename);
-    this.setDownloaded();
+    this.setDownloaded(true);
   };
 
   downloadActiveContent = () => {
@@ -304,6 +304,9 @@ export default class OutputStore {
     }
     zip
       .generateAsync({ type: "blob" })
-      .then((blob) => saveAs(blob, `${this.name}.zip`));
+      .then((blob) => {
+        saveAs(blob, `${this.name}.zip`);
+        this.setDownloaded(true);
+      });
   };
 }


### PR DESCRIPTION
## Summary
- fix the output download state so completed downloads advance the UI flow
- remove Google Analytics to match the app's privacy guarantees
- keep the Infomap runtime instance stable across re-renders
- stop leaking D3 simulations and async updates in the network renderer

## Validation
- ran `git diff --check`
- could not run `lint` or `build` because this environment does not have Node.js tooling installed
